### PR TITLE
feat(recipes): implement recipe listing API with pagination for homepage

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -23,7 +23,7 @@ model recipes {
   thumbnail_image_url  String?
   is_published         Boolean       @default(false)
   created_at           DateTime      @default(now()) @db.Timestamptz(6)
-  updated_at           DateTime      @default(now()) @db.Timestamp(6)
+  updated_at           DateTime      @default(now()) @db.Timestamptz(6)
   large_image_url      String?
   users_cooking        users_cooking @relation(fields: [author_id], references: [id], onDelete: Cascade)
 }
@@ -36,10 +36,10 @@ model users_cooking {
   password_hash                 String?   @db.VarChar
   google_id                     String?   @unique @db.VarChar
   email_verified                Boolean   @default(false)
-  display_name                  String?   @db.VarChar
+  display_name                  String    @db.VarChar
   avatar_url                    String?   @db.VarChar
   created_at                    DateTime  @default(now()) @db.Timestamptz(6)
-  updated_at                    DateTime  @default(now()) @db.Timestamp(6)
+  updated_at                    DateTime  @default(now()) @db.Timestamptz(6)
   verification_token            String?   @unique
   verification_token_expired_at DateTime? @db.Timestamp(6)
   recipes                       recipes[]

--- a/src/controllers/recipes.ts
+++ b/src/controllers/recipes.ts
@@ -111,17 +111,18 @@ export interface RecipeAllRequest {
 }
 export const getAllRecipes = async (request: FastifyRequest<{ Querystring: RecipeAllRequest }>, reply: FastifyReply) => {
   try {
-    const { page, limit } = request.query;
-    if (limit > 20) {
-      throw new Error('The limit should be <=20');
+    const page = parseInt(request.query.page?.toString() || '1', 10);
+    const limit = parseInt(request.query.limit?.toString() || '10', 10);
+    if (isNaN(page) || page < 1) {
+      throw new Error('Page must be a positive integer starting from 1');
     }
-    if (page <= 0) {
-      throw new Error('The page should start from 1');
+    if (isNaN(limit) || limit < 1 || limit > 20) {
+      throw new Error('Limit must be between 1 and 20');
     }
-    const { recipeData, totalItems, hasMore } = await recipeService.fetchAllRecipes(Number(page), Number(limit));
+    const { recipeData, totalItems, hasMore } = await recipeService.fetchAllRecipes(page, limit);
     return reply.status(200).send({
       success: true,
-      message: 'Recipe for the homepage has been fetched succesfully',
+      message: 'Recipe for the homepage has been fetched successfully',
       data: {
         recipeData,
         totalItems,

--- a/src/controllers/recipes.ts
+++ b/src/controllers/recipes.ts
@@ -105,7 +105,7 @@ export const createRecipe = async (request: FastifyRequest, reply: FastifyReply)
   }
 };
 
-interface RecipeAllRequest {
+export interface RecipeAllRequest {
   page: number;
   limit: number;
 }
@@ -118,7 +118,7 @@ export const getAllRecipes = async (request: FastifyRequest<{ Querystring: Recip
     if (page <= 0) {
       throw new Error('The page should start from 1');
     }
-    const { recipeData, totalItems, hasMore } = await recipeService.fetchAllRecipes(page, limit);
+    const { recipeData, totalItems, hasMore } = await recipeService.fetchAllRecipes(Number(page), Number(limit));
     return reply.status(200).send({
       success: true,
       message: 'Recipe for the homepage has been fetched succesfully',

--- a/src/controllers/recipes.ts
+++ b/src/controllers/recipes.ts
@@ -104,3 +104,40 @@ export const createRecipe = async (request: FastifyRequest, reply: FastifyReply)
     });
   }
 };
+
+interface RecipeAllRequest {
+  page: number;
+  limit: number;
+}
+export const getAllRecipes = async (request: FastifyRequest<{ Querystring: RecipeAllRequest }>, reply: FastifyReply) => {
+  try {
+    const { page, limit } = request.query;
+    if (limit > 20) {
+      throw new Error('The limit should be <=20');
+    }
+    if (page <= 0) {
+      throw new Error('The page should start from 1');
+    }
+    const { recipeData, totalItems, hasMore } = await recipeService.fetchAllRecipes(page, limit);
+    return reply.status(200).send({
+      success: true,
+      message: 'Recipe for the homepage has been fetched succesfully',
+      data: {
+        recipeData,
+        totalItems,
+        hasMore,
+      },
+    });
+  } catch (error) {
+    if (error instanceof Error) {
+      return reply.status(400).send({
+        success: false,
+        error: error.message,
+      });
+    }
+    return reply.status(500).send({
+      success: false,
+      error: 'Internal server error',
+    });
+  }
+};

--- a/src/repositories/recipes.ts
+++ b/src/repositories/recipes.ts
@@ -73,3 +73,38 @@ export const saveRecipeWithoutImages = async (recipeData: {
   });
   return recipe;
 };
+
+export const fetchRecipesUsingOffsetAndLimit = async (offset: number, limit: number) => {
+  const recipeData = await prisma.recipes.findMany({
+    select: {
+      id: true,
+      title: true,
+      prep_time_minutes: true,
+      cooking_time_minutes: true,
+      serving_size: true,
+      thumbnail_image_url: true,
+      users_cooking: {
+        select: {
+          display_name: true,
+          avatar_url: true,
+        },
+      },
+    },
+
+    where: {
+      is_published: true,
+    },
+    orderBy: {
+      updated_at: 'desc',
+    },
+    skip: offset,
+    take: limit,
+  });
+
+  const publishedRecipesCount = await prisma.recipes.count({ where: { is_published: true } });
+
+  return {
+    recipeData,
+    totalItems: publishedRecipesCount,
+  };
+};

--- a/src/routes/recipes.ts
+++ b/src/routes/recipes.ts
@@ -1,11 +1,11 @@
-import { FastifyPluginAsync } from 'fastify';
+import { FastifyPluginAsync, FastifyRequest } from 'fastify';
 import authenticateToken from '@/middleware/auth';
-import { createRecipe } from '@/controllers/recipes';
+import { createRecipe, getAllRecipes, RecipeAllRequest } from '@/controllers/recipes';
 
 const recipeRoutes: FastifyPluginAsync = async fastify => {
   // Public routes (no auth required)
-  fastify.get('/', async (_request, _reply) => {
-    return { success: true, message: 'Get all recipes - TODO' };
+  fastify.get('/', async (request: FastifyRequest<{ Querystring: RecipeAllRequest }>, reply) => {
+    await getAllRecipes(request, reply);
   });
 
   fastify.get('/:id', async (_request, _reply) => {

--- a/src/services/recipes.ts
+++ b/src/services/recipes.ts
@@ -34,12 +34,12 @@ export class RecipeService {
   };
 
   fetchAllRecipes = async (page: number, limit: number): Promise<RecipeData> => {
-    const offset = (page - 1) * 20;
+    const offset = (page - 1) * limit;
     const { recipeData, totalItems } = await fetchRecipesUsingOffsetAndLimit(offset, limit);
     const hasMore = page * limit <= totalItems;
     const formattedRecipedData = recipeData.map(item => {
       return {
-        recipedId: item.id,
+        recipeId: item.id,
         title: item.title,
         prepTimeMinutes: item.prep_time_minutes,
         cookingTimeMinutes: item.cooking_time_minutes,

--- a/src/services/recipes.ts
+++ b/src/services/recipes.ts
@@ -1,4 +1,5 @@
-import { createRecipeWithImagesTransaction, saveRecipeWithoutImages } from '@/repositories/recipes';
+import { createRecipeWithImagesTransaction, fetchRecipesUsingOffsetAndLimit, saveRecipeWithoutImages } from '@/repositories/recipes';
+import { RecipeData } from '@/types/recipe';
 
 export class RecipeService {
   createRecipeWithTransaction = async (
@@ -30,5 +31,28 @@ export class RecipeService {
     userId: string;
   }) => {
     return await saveRecipeWithoutImages(recipeData);
+  };
+
+  fetchAllRecipes = async (page: number, limit: number): Promise<RecipeData> => {
+    const offset = (page - 1) * 20;
+    const { recipeData, totalItems } = await fetchRecipesUsingOffsetAndLimit(offset, limit);
+    const hasMore = page * limit <= totalItems;
+    const formattedRecipedData = recipeData.map(item => {
+      return {
+        recipedId: item.id,
+        title: item.title,
+        prepTimeMinutes: item.prep_time_minutes,
+        cookingTimeMinutes: item.cooking_time_minutes,
+        servingSize: item.serving_size,
+        imageUrl: item.thumbnail_image_url,
+        authorName: item.users_cooking.display_name,
+        authorAvatarUrl: item.users_cooking.avatar_url,
+      };
+    });
+    return {
+      recipeData: formattedRecipedData,
+      totalItems,
+      hasMore,
+    };
   };
 }

--- a/src/types/recipe.ts
+++ b/src/types/recipe.ts
@@ -1,0 +1,16 @@
+interface RecipeDataForHomePage {
+  recipedId: string;
+  title: string;
+  prepTimeMinutes: number;
+  cookingTimeMinutes: number;
+  servingSize: number;
+  imageUrl: string | null;
+  authorName: string;
+  authorAvatarUrl: string | null;
+}
+
+export interface RecipeData {
+  recipeData: RecipeDataForHomePage[];
+  totalItems: number;
+  hasMore: boolean;
+}

--- a/src/types/recipe.ts
+++ b/src/types/recipe.ts
@@ -1,5 +1,5 @@
 interface RecipeDataForHomePage {
-  recipedId: string;
+  recipeId: string;
   title: string;
   prepTimeMinutes: number;
   cookingTimeMinutes: number;


### PR DESCRIPTION
### What Changed?
- Added GET /api/recipes endpoint for fetching published recipes with pagination
- Implemented recipe listing functionality with offset-based pagination (page/limit)
- Added recipe data formatting layer with clean response structure
- Created RecipeData type interface for consistent API responses
- Added query parameter validation for page (1-∞) and limit (1-20)
- Implemented database queries with proper ordering (newest first) and published-only filtering
- Added author information (display name, avatar) in recipe listings
- Fixed database schema issues (updated_at timezone, display_name non-null constraint)

### Why was this change made?
- Homepage needs to display a list of published recipes for users to browse
- Pagination is essential for performance and user experience with large recipe datasets
- Clean data formatting ensures consistent API responses for frontend consumption
- Author information enhances recipe discoverability and social aspects
- Input validation prevents abuse and ensures reliable pagination behavior

### How to Test?
1. Check out this branch
2. Run `make dev-up` to start the development server
3. Test recipe listing endpoint:
   - GET /api/recipes (default pagination: page=1, limit=10)
   - GET /api/recipes?page=1&limit=5 (custom pagination)
   - GET /api/recipes?page=2&limit=10 (second page test)
4. Verify response structure includes:
   - recipeData array with formatted recipe objects
   - totalItems count
   - hasMore boolean for pagination logic
   - Each recipe includes: recipeId, title, prepTime, cookingTime, servingSize, imageUrl, authorName, authorAvatarUrl
5. Test edge cases:
   - Invalid page numbers (0, negative, non-numeric)
   - Invalid limits (0, >20, non-numeric)
   - Verify only published recipes are returned
   - Verify newest recipes appear first
