### PR TITLE
feat(recipes): add endpoint to get recipes per author

### DIFF
--- a/src/controllers/recipes.ts
+++ b/src/controllers/recipes.ts
@@ -107,7 +107,7 @@ export const getAllRecipes = async (request: FastifyRequest<{ Querystring: Recip
     const { recipeData, totalItems, hasMore } = await recipeService.fetchAllRecipes(page, limit);
     return reply.status(200).send({
       success: true,
-      message: 'Recipe for the homepage has been fetched successfully',
+      message: 'Recipes for the homepage has been fetched successfully',
       data: {
         recipeData,
         totalItems,
@@ -132,6 +132,25 @@ export const getDetailRecipe = async (request: FastifyRequest<{ Params: RecipeDe
       message: 'Recipe detail has been fetched successfully',
       data: {
         recipeDetailData,
+      },
+    });
+  } catch (error) {
+    return handleError(reply, error);
+  }
+};
+
+export const getRecipesPerAuthor = async (request: FastifyRequest<{ Querystring: RecipeAllRequest }>, reply: FastifyReply) => {
+  try {
+    const { page, limit } = request.query;
+    const userId = (request as AuthenticatedRequest).user.userId;
+    const { recipeData, totalItems, hasMore } = await recipeService.fetchRecipesPerAuthor(page, limit, userId);
+    return reply.status(200).send({
+      success: true,
+      message: 'Author personal recipes have been fetched successfully',
+      data: {
+        recipeData,
+        totalItems,
+        hasMore,
       },
     });
   } catch (error) {

--- a/src/repositories/recipes.ts
+++ b/src/repositories/recipes.ts
@@ -132,7 +132,35 @@ export const fetchDetailRecipeFromDB = async (recipeId: string) => {
     },
   });
   if (!detailRecipe) {
-    throw new Error('This reciped does not exist');
+    throw new Error('This recipe does not exist');
   }
   return detailRecipe;
+};
+
+export const fetchRecipesPerAuthorFromDB = async (userId: string, offset: number, limit: number) => {
+  const recipeData = await prisma.recipes.findMany({
+    select: {
+      id: true,
+      title: true,
+      prep_time_minutes: true,
+      cooking_time_minutes: true,
+      serving_size: true,
+      thumbnail_image_url: true,
+    },
+    where: {
+      author_id: userId,
+    },
+    orderBy: {
+      updated_at: 'desc',
+    },
+    skip: offset,
+    take: limit,
+  });
+
+  const publishedRecipesCount = await prisma.recipes.count({ where: { author_id: userId } });
+
+  return {
+    recipeData,
+    totalItems: publishedRecipesCount,
+  };
 };

--- a/src/routes/recipes.ts
+++ b/src/routes/recipes.ts
@@ -1,8 +1,16 @@
 import { FastifyPluginAsync, FastifyRequest } from 'fastify';
 import authenticateToken from '@/middleware/auth';
-import { createRecipe, getAllRecipes, getDetailRecipe, RecipeAllRequest, RecipeDetailParams } from '@/controllers/recipes';
+import {
+  createRecipe,
+  getAllRecipes,
+  getDetailRecipe,
+  RecipeAllRequest,
+  RecipeDetailParams,
+  getRecipesPerAuthor,
+} from '@/controllers/recipes';
 import { getAllRecipesSchema } from '@/schema/recipes/getAll';
 import { getRecipeByIdSchema } from '@/schema/recipes/getById';
+import { getAuthorRecipesSchema } from '@/schema/recipes/getAuthor';
 
 const recipeRoutes: FastifyPluginAsync = async fastify => {
   // Public routes (no auth required)
@@ -11,16 +19,23 @@ const recipeRoutes: FastifyPluginAsync = async fastify => {
     {
       schema: getAllRecipesSchema,
     },
-    async (request: FastifyRequest<{ Querystring: RecipeAllRequest }>, reply) => {
-      await getAllRecipes(request, reply);
+    async (request, reply) => {
+      await getAllRecipes(request as FastifyRequest<{ Querystring: RecipeAllRequest }>, reply);
     }
   );
 
-  fastify.get('/:id', { schema: getRecipeByIdSchema }, async (request: FastifyRequest<{ Params: RecipeDetailParams }>, reply) => {
-    await getDetailRecipe(request, reply);
-  });
+  // Protected routes (auth required) - Place static routes before dynamic ones
+  fastify.get(
+    '/author',
+    {
+      preHandler: authenticateToken,
+      schema: getAuthorRecipesSchema,
+    },
+    async (request, reply) => {
+      await getRecipesPerAuthor(request as FastifyRequest<{ Querystring: RecipeAllRequest }>, reply);
+    }
+  );
 
-  // Protected routes (auth required)
   fastify.post(
     '/',
     {
@@ -30,6 +45,11 @@ const recipeRoutes: FastifyPluginAsync = async fastify => {
       await createRecipe(request, reply);
     }
   );
+
+  // Dynamic routes (must come after static routes)
+  fastify.get('/:id', { schema: getRecipeByIdSchema }, async (request, reply) => {
+    await getDetailRecipe(request as FastifyRequest<{ Params: RecipeDetailParams }>, reply);
+  });
 
   fastify.put('/:id', async (_request, _reply) => {
     return { success: true, message: 'Update recipe - TODO' };

--- a/src/schema/recipes/getAuthor.ts
+++ b/src/schema/recipes/getAuthor.ts
@@ -1,0 +1,72 @@
+/**
+ * Schema for GET /recipes/author - Get Author's Recipes endpoint
+ */
+import { FastifySchema } from 'fastify';
+import { paginationQuerySchema, paginatedResponseDataSchema } from './pagination';
+
+const authorRecipeItemSchema = {
+  type: 'object',
+  properties: {
+    recipeId: {
+      type: 'string',
+      format: 'uuid',
+      description: 'Unique recipe identifier',
+    },
+    title: {
+      type: 'string',
+      description: 'Recipe title',
+    },
+    prepTimeMinutes: {
+      type: 'integer',
+      minimum: 0,
+      description: 'Preparation time in minutes',
+    },
+    cookingTimeMinutes: {
+      type: 'integer',
+      minimum: 0,
+      description: 'Cooking time in minutes',
+    },
+    servingSize: {
+      type: 'integer',
+      minimum: 1,
+      description: 'Number of servings',
+    },
+    imageUrl: {
+      type: ['string', 'null'],
+      format: 'uri',
+      description: 'Recipe thumbnail image URL',
+    },
+  },
+  required: ['recipeId', 'title', 'prepTimeMinutes', 'cookingTimeMinutes', 'servingSize', 'imageUrl'],
+  additionalProperties: false,
+} as const;
+
+export const getAuthorRecipesSchema: FastifySchema = {
+  querystring: paginationQuerySchema,
+
+  response: {
+    200: {
+      type: 'object',
+      properties: {
+        success: { type: 'boolean', const: true },
+        message: { type: 'string' },
+        data: {
+          type: 'object',
+          properties: {
+            recipeData: {
+              type: 'array',
+              items: authorRecipeItemSchema,
+              description: 'Array of author recipe items',
+            },
+            ...paginatedResponseDataSchema.properties,
+          },
+          required: ['recipeData', 'totalItems', 'hasMore'],
+          additionalProperties: false,
+        },
+      },
+      required: ['success', 'message', 'data'],
+      additionalProperties: false,
+      description: 'Successful response with author recipe list',
+    },
+  },
+} as const;

--- a/src/services/recipes.ts
+++ b/src/services/recipes.ts
@@ -1,10 +1,11 @@
 import {
   createRecipeWithImagesTransaction,
   fetchDetailRecipeFromDB,
+  fetchRecipesPerAuthorFromDB,
   fetchRecipesUsingOffsetAndLimit,
   saveRecipeWithoutImages,
 } from '@/repositories/recipes';
-import { RecipeData, RecipeDetailData } from '@/types/recipe';
+import { RecipeData, RecipeDetailData, RecipeWithoutAuthorData } from '@/types/recipe';
 
 export class RecipeService {
   createRecipeWithTransaction = async (
@@ -78,5 +79,26 @@ export class RecipeService {
       authorAvatarUrl: detailRecipe.users_cooking.avatar_url,
     };
     return formattedDetailRecipe;
+  };
+
+  fetchRecipesPerAuthor = async (page: number, limit: number, userId: string): Promise<RecipeWithoutAuthorData> => {
+    const offset = (page - 1) * limit;
+    const { recipeData, totalItems } = await fetchRecipesPerAuthorFromDB(userId, offset, limit);
+    const hasMore = page * limit <= totalItems;
+    const formattedRecipedData = recipeData.map(item => {
+      return {
+        recipeId: item.id,
+        title: item.title,
+        prepTimeMinutes: item.prep_time_minutes,
+        cookingTimeMinutes: item.cooking_time_minutes,
+        servingSize: item.serving_size,
+        imageUrl: item.thumbnail_image_url,
+      };
+    });
+    return {
+      recipeData: formattedRecipedData,
+      totalItems,
+      hasMore,
+    };
   };
 }

--- a/src/types/recipe.ts
+++ b/src/types/recipe.ts
@@ -9,8 +9,16 @@ interface RecipeDataForHomePage {
   authorAvatarUrl: string | null;
 }
 
+type RecipeDataWithoutAuthor = Omit<RecipeDataForHomePage, 'authorName' | 'authorAvatarUrl'>;
+
 export interface RecipeData {
   recipeData: RecipeDataForHomePage[];
+  totalItems: number;
+  hasMore: boolean;
+}
+
+export interface RecipeWithoutAuthorData {
+  recipeData: RecipeDataWithoutAuthor[];
   totalItems: number;
   hasMore: boolean;
 }


### PR DESCRIPTION
### What Changed?

Added a new authenticated endpoint `GET /recipes/author` that allows users to fetch their own published recipes. This includes a complete implementation across the full stack with proper schema validation and pagination support.

### Why was this change made?

This feature enables authors/users to view and manage their own recipe collection, providing a personalized dashboard functionality. It supports the user profile features where authors can see all recipes they've created.

### How to Test?

1. Check out this branch
2. Run `npm run dev` to start the development server
3. Authenticate with a valid user token
4. Make a GET request to `/recipes/author?page=1&limit=10` with Authorization header
5. Verify that only recipes created by the authenticated user are returned
6. Test pagination by varying page and limit parameters
7. Verify the response follows the defined schema structure

### Technical Details

- **Endpoint**: `GET /recipes/author` (authenticated)
- **Query params**: `page` and `limit` for pagination
- **Response**: Paginated list of author's recipes without author info (since it's their own recipes)
- **Security**: Requires valid JWT authentication
- **Schema**: Full Fastify schema validation for request/response