### PR TITLE
feat(recipes): add owner identification to recipe detail endpoint

### DIFF
--- a/src/controllers/recipes.ts
+++ b/src/controllers/recipes.ts
@@ -126,7 +126,8 @@ export interface RecipeDetailParams {
 export const getDetailRecipe = async (request: FastifyRequest<{ Params: RecipeDetailParams }>, reply: FastifyReply) => {
   try {
     const { id } = request.params;
-    const recipeDetailData = await recipeService.fetchDetailRecipe(id);
+    const userId = (request as AuthenticatedRequest).user?.userId;
+    const recipeDetailData = await recipeService.fetchDetailRecipe(id, userId);
     return reply.status(200).send({
       success: true,
       message: 'Recipe detail has been fetched successfully',

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -36,4 +36,13 @@ export const authenticateToken = (request: FastifyRequest, reply: FastifyReply, 
   }
 };
 
-export default authenticateToken;
+export const allowEmptyToken = (request: FastifyRequest, reply: FastifyReply, done: HookHandlerDoneFunction) => {
+  const jwtService = new JWTService();
+  const userToken = request.cookies.recipe_token_user;
+  if (userToken) {
+    const decodedToken = jwtService.verifyAccessToken(userToken);
+    (request as AuthenticatedRequest).user = decodedToken;
+    done();
+  }
+  done();
+};

--- a/src/repositories/recipes.ts
+++ b/src/repositories/recipes.ts
@@ -123,6 +123,7 @@ export const fetchDetailRecipeFromDB = async (recipeId: string) => {
       serving_size: true,
       large_image_url: true,
       updated_at: true,
+      author_id: true,
       users_cooking: {
         select: {
           display_name: true,

--- a/src/routes/recipes.ts
+++ b/src/routes/recipes.ts
@@ -1,5 +1,5 @@
 import { FastifyPluginAsync, FastifyRequest } from 'fastify';
-import authenticateToken from '@/middleware/auth';
+import { authenticateToken, allowEmptyToken } from '@/middleware/auth';
 import {
   createRecipe,
   getAllRecipes,
@@ -13,7 +13,6 @@ import { getRecipeByIdSchema } from '@/schema/recipes/getById';
 import { getAuthorRecipesSchema } from '@/schema/recipes/getAuthor';
 
 const recipeRoutes: FastifyPluginAsync = async fastify => {
-  // Public routes (no auth required)
   fastify.get(
     '/',
     {
@@ -24,7 +23,6 @@ const recipeRoutes: FastifyPluginAsync = async fastify => {
     }
   );
 
-  // Protected routes (auth required) - Place static routes before dynamic ones
   fastify.get(
     '/author',
     {
@@ -46,8 +44,7 @@ const recipeRoutes: FastifyPluginAsync = async fastify => {
     }
   );
 
-  // Dynamic routes (must come after static routes)
-  fastify.get('/:id', { schema: getRecipeByIdSchema }, async (request, reply) => {
+  fastify.get('/:id', { preHandler: allowEmptyToken, schema: getRecipeByIdSchema }, async (request, reply) => {
     await getDetailRecipe(request as FastifyRequest<{ Params: RecipeDetailParams }>, reply);
   });
 

--- a/src/schema/recipes/getById.ts
+++ b/src/schema/recipes/getById.ts
@@ -63,6 +63,10 @@ const recipeDetailSchema = {
       format: 'uri',
       description: 'Author avatar image URL',
     },
+    isOwner: {
+      type: 'boolean',
+      description: 'Is recipe belong to author or not',
+    },
   },
   required: [
     'id',
@@ -77,6 +81,7 @@ const recipeDetailSchema = {
     'recipeUpdatedAt',
     'authorName',
     'authorAvatarUrl',
+    'isOwner',
   ],
   additionalProperties: false,
 } as const;

--- a/src/services/recipes.ts
+++ b/src/services/recipes.ts
@@ -62,7 +62,7 @@ export class RecipeService {
     };
   };
 
-  fetchDetailRecipe = async (recipeId: string): Promise<RecipeDetailData> => {
+  fetchDetailRecipe = async (recipeId: string, userId: string | undefined): Promise<RecipeDetailData> => {
     const detailRecipe = await fetchDetailRecipeFromDB(recipeId);
     const formattedDetailRecipe = {
       id: detailRecipe.id,
@@ -77,6 +77,7 @@ export class RecipeService {
       recipeUpdatedAt: detailRecipe.updated_at,
       authorName: detailRecipe.users_cooking.display_name,
       authorAvatarUrl: detailRecipe.users_cooking.avatar_url,
+      isOwner: userId ? userId === detailRecipe.author_id : false,
     };
     return formattedDetailRecipe;
   };

--- a/src/types/recipe.ts
+++ b/src/types/recipe.ts
@@ -36,4 +36,5 @@ export interface RecipeDetailData {
   recipeUpdatedAt: Date;
   authorName: string;
   authorAvatarUrl: string | null;
+  isOwner: boolean;
 }


### PR DESCRIPTION
### What Changed?

Added owner identification functionality to the recipe detail endpoint. The API now returns an `isOwner` boolean field that indicates whether the requesting user is the owner of the recipe.

### Why was this change made?

This feature enables the frontend to differentiate between users and recipe authors, allowing for conditional UI elements (e.g., edit/delete buttons) to be displayed only to recipe owners. This improves user experience by providing appropriate access controls and interface customization.

### How to Test?

1. Check out this branch: `git checkout fix/differentiate-user-and-author-on-recipe-detail`
2. Start the API server: `npm run dev`
3. Test as an authenticated user (recipe owner):
   - Login and get a recipe created by that user
   - Verify the response includes `"isOwner": true`
4. Test as an unauthenticated user:
   - Access any recipe detail endpoint without authentication
   - Verify the response includes `"isOwner": false`
5. Test as a different authenticated user:
   - Login as a different user and access another user's recipe
   - Verify the response includes `"isOwner": false`

### Technical Details

- Added `allowEmptyToken` middleware for optional authentication
- Updated `fetchDetailRecipe` service method to accept `userId` parameter
- Modified recipe detail endpoint to use optional authentication
- Extended `RecipeDetailData` type and API schema with `isOwner` field
- Updated database query to include `author_id` for ownership comparison