### PR TITLE
refactor: pass only 1 argument to the process image pipeline and use destructuring

### DIFF
--- a/src/utils/recipeUtils.ts
+++ b/src/utils/recipeUtils.ts
@@ -39,14 +39,23 @@ export const processMultipartRequest = async (request: FastifyRequest): Promise<
   return { imageFile, formFields };
 };
 
+interface ImagePipeline {
+  userData: {
+    imageFile: EnhancedMultipartFile;
+    userId: string;
+    recipeId: string;
+  };
+  services: {
+    imageService: ImageService;
+    s3Service: S3Service;
+  };
+}
+
 // Utility function to process image pipeline
-export const processImagePipeline = async (
-  imageFile: EnhancedMultipartFile,
-  userId: string,
-  recipeId: string,
-  imageService: ImageService,
-  s3Service: S3Service
-): Promise<ImageProcessingResult> => {
+export const processImagePipeline = async (imagePipelineData: ImagePipeline): Promise<ImageProcessingResult> => {
+  const { userData, services } = imagePipelineData;
+  const { imageFile, userId, recipeId } = userData;
+  const { imageService, s3Service } = services;
   // 1. Validate image
   const imageBuffer = imageFile.buffer;
   const mimeType = imageFile.mimetype;


### PR DESCRIPTION
### What Changed?

Refactored the `processImagePipeline` function to accept a single structured parameter object instead of multiple individual parameters, improving code maintainability and readability.

### Why was this change made?

- **Reduced Parameter Complexity**: The function previously accepted 5 separate parameters (`imageFile`, `userId`, `recipeId`, `imageService`, `s3Service`), which made the function signature unwieldy and harder to maintain as requirements grow.
- **Improved Code Organization**: Parameters are now logically grouped into `userData` (business data) and `services` (dependencies), making the function's requirements clearer.
- **Enhanced Type Safety**: Introduced the `ImagePipeline` interface to provide compile-time validation of the expected parameter structure.
- **Better Maintainability**: Future changes to the pipeline will be easier to implement as new parameters can be added to the appropriate object rather than extending the function signature.

### How to Test?

1. Check out this branch
2. Run `npm install` to ensure dependencies are up to date
3. Run `npm run build` to verify TypeScript compilation passes
4. Run `npm run test` to ensure all existing tests pass
5. Test recipe creation and update endpoints:
   - POST /recipes with image upload
   - PUT /recipes/:id with image upload
6. Verify that image processing still works correctly by checking uploaded images in S3
7. Confirm no functional changes - only the internal parameter structure has changed